### PR TITLE
Fix installation error

### DIFF
--- a/app/view/estacas.py
+++ b/app/view/estacas.py
@@ -84,7 +84,7 @@ EXPORTAR_CORTE, _ = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "../view/ui/cortePreview.ui")
 )
 
-rb = QgsRubberBand(iface.mapCanvas(), 1)
+rb = QgsRubberBand(iface.mapCanvas(), QgsWkbTypes.GeometryType.Line)
 premuto = False
 point0 = iface.mapCanvas().getCoordinateTransform().toMapCoordinates(0, 0)
 


### PR DESCRIPTION
Hi,
this update seems to fix an installation issue using QGIS 3.34.15 on Windows 10 (see the error message below) thanks to [this post](https://gis.stackexchange.com/questions/455784/typeerror-qgsrubberband-argument-2-has-unexpected-type-bool) on StackExchange.


Here the message:
```
Couldn't load plugin 'Topografia-master' due to an error when calling its classFactory() method 

TypeError: QgsRubberBand(): argument 2 has unexpected type 'int' 
Traceback (most recent call last):
  File "C:\OSGeo4W/apps/qgis-ltr/./python\qgis\utils.py", line 423, in _startPlugin
    plugins[packageName] = package.classFactory(iface)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/.../AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\Topografia-master\__init__.py", line 48, in classFactory
    from .main import TopoGrafia
  File "C:\OSGeo4W/apps/qgis-ltr/./python\qgis\utils.py", line 892, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/.../AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\Topografia-master\main.py", line 25, in 
    from . import install_deps
  File "C:\OSGeo4W/apps/qgis-ltr/./python\qgis\utils.py", line 892, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/.../AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\Topografia-master\install_deps.py", line 4, in 
    from .app.controller.estacas import msgLog
  File "C:\OSGeo4W/apps/qgis-ltr/./python\qgis\utils.py", line 892, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/.../AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\Topografia-master\app\controller\estacas.py", line 12, in 
    from ..controller.perfil import Ui_Bruckner, Ui_Perfil, Ui_sessaoTipo
  File "C:\OSGeo4W/apps/qgis-ltr/./python\qgis\utils.py", line 892, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/.../AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\Topografia-master\app\controller\perfil.py", line 15, in 
    from ..view.estacas import (ApplyTransDialog, QgsMessageLog, SetCtAtiDialog,
  File "C:\OSGeo4W/apps/qgis-ltr/./python\qgis\utils.py", line 892, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/.../AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\Topografia-master\app\view\estacas.py", line 87, in 
    rb = QgsRubberBand(iface.mapCanvas(), 1)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: QgsRubberBand(): argument 2 has unexpected type 'int'
```

